### PR TITLE
Add modal toggle on 'Ctrl + m'

### DIFF
--- a/src/app/scripts/examples/examples.js
+++ b/src/app/scripts/examples/examples.js
@@ -4,6 +4,7 @@
 // make note that you need to use relative paths here, path starts with './'
 import testLogger from './testLog';
 import testLogger2 from './testLog2';
+import './toggleModals';
 
 console.log('::::::::::: use properties :::::::::::');
 console.log(testLogger.property);

--- a/src/app/scripts/examples/toggleModals.js
+++ b/src/app/scripts/examples/toggleModals.js
@@ -1,0 +1,13 @@
+const doc = document.querySelector('body');
+const modals = document.querySelectorAll('.modal');
+
+doc.addEventListener('keydown', function (e) {
+    // Use 'Ctrl + m' to toggle modals (only until they are integrated properly)
+    if (e.key === 'm' && e.ctrlKey) toggleModals(modals);
+});
+
+function toggleModals(collection) {
+    collection.forEach(modal => {
+        modal.classList.toggle('hidden');
+    });
+}

--- a/src/index.html
+++ b/src/index.html
@@ -13,9 +13,8 @@
     <header class='site-header'>
 
       <!-- settings modal -->
-      <div class="modal">
+      <div class="modal modal-settings hidden">
         <div class="modal-content">
-          <span class="settings-tooltip"></span>
           <h1 class="settings-header">Select the Technologies That Interest You</h1>
           <div class="tech-container">
             <div class="tech-box">
@@ -46,7 +45,7 @@
                   <div class="checkbox-container">
                     <input class="tech-selection" type="checkbox" name="framework" id='other'>
                     <label for="other"><span class="checkbox"></span>Other JS Frameworks</label>
-                  </div>      
+                  </div>
                   <div class="checkbox-container">
                     <input class="tech-selection" type="checkbox" name="framework" id='meteor'>
                     <label for="meteor"><span class="checkbox"></span>Meteor.js</label>
@@ -78,7 +77,7 @@
                   <div class="checkbox-container">
                     <input class="tech-selection" type="checkbox" name="language" id='scala'>
                     <label for="scala"><span class="checkbox"></span>Scala</label>
-                  </div>  
+                  </div>
                   <div class="checkbox-container">
                     <input class="tech-selection" type="checkbox" name="language" id='python'>
                     <label for="python"><span class="checkbox"></span>Python</label>
@@ -141,7 +140,7 @@
                 <label for="news"><span class="checkbox"></span>Hot Industry News</label>
               </div>
             </div>
-          </div>     
+          </div>
           <!-- footer of modal -->
           <footer class="settings-modal-footer">
             <span class="settings-modal-footer-item fa fa-info-circle" aria-hidden="true"></span>

--- a/src/styles/base/_helperClasses.scss
+++ b/src/styles/base/_helperClasses.scss
@@ -1,0 +1,3 @@
+.hidden {
+    display: none !important;
+}

--- a/src/styles/components/_settingsModal.scss
+++ b/src/styles/components/_settingsModal.scss
@@ -1,4 +1,4 @@
-.modal {
+.modal-settings {
   color: $white;
   background-color: $white;
   position: absolute;
@@ -17,16 +17,17 @@
   margin: auto;
   height: 90%;
   width: 90%;
-}
-
-.settings-tooltip {
-  background-color: $red;
-  height: 40px;
-  position: absolute;
-  top: -13px;
-  right: 6rem;
-  width: 20px;
-  transform: rotate(45deg);
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 6rem;
+    border: 12px solid transparent;
+    box-sizing: border-box;
+    border-bottom: 16px solid $red;
+    transform: translateY(-100%);
+  }
 }
 
 .settings-header {

--- a/src/styles/layout/_layout.scss
+++ b/src/styles/layout/_layout.scss
@@ -37,4 +37,3 @@ body {
 .developer-videos {
   background: red;
 }
-

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,5 +1,6 @@
 @import 'base/colors';
 @import 'base/typography';
+@import 'base/_helperClasses';
 
 // layout
 @import 'layout/layout';


### PR DESCRIPTION
Until the modals are properly integrated, by pressing `Ctrl + m` they can be toggled.
Every modal should have the `modal` class on the modal root element for this to work.
If you want the modal to be hidden by default, add the class `hidden` to the modal root element in html.